### PR TITLE
Adjust dashboard tags and refresh rate

### DIFF
--- a/files/dashboards/apiserver.json
+++ b/files/dashboards/apiserver.json
@@ -28,7 +28,7 @@
          "type": "text"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -1442,7 +1442,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/cluster-total.json
+++ b/files/dashboards/cluster-total.json
@@ -1528,12 +1528,12 @@
          "type": "row"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 18,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/controller-manager.json
+++ b/files/dashboards/controller-manager.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -924,7 +924,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/k8s-resources-cluster.json
+++ b/files/dashboards/k8s-resources-cluster.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -2140,7 +2140,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/k8s-resources-multicluster.json
+++ b/files/dashboards/k8s-resources-multicluster.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -1127,7 +1127,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/k8s-resources-namespace.json
+++ b/files/dashboards/k8s-resources-namespace.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -1877,7 +1877,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/k8s-resources-node.json
+++ b/files/dashboards/k8s-resources-node.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -731,7 +731,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/k8s-resources-pod.json
+++ b/files/dashboards/k8s-resources-pod.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -1398,7 +1398,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/k8s-resources-workload.json
+++ b/files/dashboards/k8s-resources-workload.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -1575,7 +1575,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/k8s-resources-workloads-namespace.json
+++ b/files/dashboards/k8s-resources-workloads-namespace.json
@@ -7,7 +7,7 @@
    "graphTooltip": 0,
    "hideControls": false,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -1746,7 +1746,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/kubelet.json
+++ b/files/dashboards/kubelet.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -2152,7 +2152,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/namespace-by-pod.json
+++ b/files/dashboards/namespace-by-pod.json
@@ -1122,12 +1122,12 @@
          "type": "row"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 18,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/namespace-by-workload.json
+++ b/files/dashboards/namespace-by-workload.json
@@ -1334,12 +1334,12 @@
          "type": "row"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 18,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/persistentvolumesusage.json
+++ b/files/dashboards/persistentvolumesusage.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -378,7 +378,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/pod-total.json
+++ b/files/dashboards/pod-total.json
@@ -888,12 +888,12 @@
          "type": "row"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 18,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/proxy.json
+++ b/files/dashboards/proxy.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -992,7 +992,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/scheduler.json
+++ b/files/dashboards/scheduler.json
@@ -10,7 +10,7 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [
       {
          "collapse": false,
@@ -859,7 +859,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/statefulset.json
+++ b/files/dashboards/statefulset.json
@@ -721,7 +721,7 @@
    "schemaVersion": 14,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/files/dashboards/workload-total.json
+++ b/files/dashboards/workload-total.json
@@ -1046,12 +1046,12 @@
          "type": "row"
       }
    ],
-   "refresh": "10s",
+   "refresh": "1m",
    "rows": [ ],
    "schemaVersion": 18,
    "style": "dark",
    "tags": [
-      "kubernetes-mixin"
+      "origin:kubernetes-mixin"
    ],
    "templating": {
       "list": [

--- a/mixin.libsonnet
+++ b/mixin.libsonnet
@@ -12,5 +12,19 @@ kubernetes {
     kubeProxySelector: 'app="kube-proxy"',
     showMultiCluster: true,
     clusterLabel: 'cluster_id',
+
+    // See https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/43c78a647d6c229ec2d0de54a82c0bc40bc8a9b2/config.libsonnet#L66-L77
+    // for the upstream data structure.
+    grafanaK8s: {
+      dashboardNamePrefix: 'Kubernetes / ',
+      linkPrefix: '.',
+      minimumTimeInterval: '1m',
+
+      // Adjust tags to use our semantical scheme
+      dashboardTags: ['origin:kubernetes-mixin'],
+
+      // Set the default refresh rate to 1m, as the upstream 10s are too short for us.
+      refresh: '1m',
+    },
   },
 }


### PR DESCRIPTION
This adjusts the dashboard tags to use the `origin:` prefix, in line with https://github.com/giantswarm/g8s-grafana/pull/289

In addition, the default refresh rate is changed from 10 seconds to 1 minute, in line with the new dashboard guidelines in https://github.com/giantswarm/giantswarm/pull/17786